### PR TITLE
feat: release 1.4.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "torch_points3d"
-version = "1.4.6+cu121" # This will be overriden by the CI at publish time
+version = "1.4.7+cu121" # This will be overriden by the CI at publish time
 description = "Point Cloud Deep Learning Extension Library for PyTorch"
 authors = ["Thomas Chaton <thomas.chaton.ai@gmail.com>", "Nicolas Chaulet <nicolas.chaulet@gmail.com>"]
 packages = [


### PR DESCRIPTION
This PR bumps the package version, new release uses Promaton PyPI-stored internal torch packages.

Here you can see the published wheel for 1.4.7 - https://pypi.dev.promaton.ai/simple/torch-points3d.